### PR TITLE
v2.1

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -17,6 +17,11 @@
       <option name="url" value="https://repo.papermc.io/repository/maven-public/" />
     </remote-repository>
     <remote-repository>
+      <option name="id" value="placeholderapi" />
+      <option name="name" value="placeholderapi" />
+      <option name="url" value="https://repo.extendedclip.com/content/repositories/placeholderapi/" />
+    </remote-repository>
+    <remote-repository>
       <option name="id" value="central" />
       <option name="name" value="Maven Central repository" />
       <option name="url" value="https://repo1.maven.org/maven2" />

--- a/.idea/libraries/Maven__me_clip_placeholderapi_2_11_2.xml
+++ b/.idea/libraries/Maven__me_clip_placeholderapi_2_11_2.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: me.clip:placeholderapi:2.11.2">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/me/clip/placeholderapi/2.11.2/placeholderapi-2.11.2.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/me/clip/placeholderapi/2.11.2/placeholderapi-2.11.2-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/me/clip/placeholderapi/2.11.2/placeholderapi-2.11.2-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Tide.iml
+++ b/Tide.iml
@@ -28,5 +28,6 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: net.md-5:bungeecord-chat:1.13-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.yaml:snakeyaml:1.23" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains:annotations:23.0.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: me.clip:placeholderapi:2.11.2" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
         </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
+        
     </repositories>
 
     <dependencies>
@@ -75,6 +80,13 @@
             <artifactId>annotations</artifactId>
             <version>23.0.0</version>
             <scope>compile</scope>
+        </dependency>
+        <!--PlaceholderAPI-->
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.2</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/cn/goldenpotato/tide/Command/SubCommands/Attach.java
+++ b/src/main/java/cn/goldenpotato/tide/Command/SubCommands/Attach.java
@@ -3,7 +3,6 @@ package cn.goldenpotato.tide.Command.SubCommands;
 import cn.goldenpotato.tide.Command.SubCommand;
 import cn.goldenpotato.tide.Config.ConfigManager;
 import cn.goldenpotato.tide.Config.MessageManager;
-import cn.goldenpotato.tide.Tide;
 import cn.goldenpotato.tide.Util.Util;
 import cn.goldenpotato.tide.Water.TideSystem;
 import org.bukkit.Bukkit;
@@ -33,8 +32,10 @@ public class Attach extends SubCommand
             Util.Message(player,MessageManager.msg.SubCommand_Attach_Already);
             return;
         }
+        ConfigManager.config.worlds.add(world.getName());
         TideSystem.Load(world);
         ConfigManager.Save();
+        TideSystem.CalcNearbyChunk(world);
         Util.Message(player,MessageManager.msg.Success);
     }
 

--- a/src/main/java/cn/goldenpotato/tide/Command/SubCommands/Reload.java
+++ b/src/main/java/cn/goldenpotato/tide/Command/SubCommands/Reload.java
@@ -7,6 +7,7 @@ import cn.goldenpotato.tide.Tide;
 import cn.goldenpotato.tide.Util.Util;
 import cn.goldenpotato.tide.Water.TideSystem;
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -25,8 +26,18 @@ public class Reload extends SubCommand
     {
         Tide.Load();
         //加载世界
-        for (String world : ConfigManager.config.worlds)
-            TideSystem.Load(Bukkit.getWorld(world));
+        for (String worldString : ConfigManager.config.worlds)
+        {
+            World world = Bukkit.getWorld(worldString);
+            if(world==null)
+            {
+                Tide.instance.getLogger().warning("No such world: %world%".replace("%world%",worldString));
+                Util.Message(player,MessageManager.msg.NoSuchWorld.replace("%world%",worldString));
+                continue;
+            }
+            TideSystem.Load(world);
+            TideSystem.CalcNearbyChunk(world);
+        }
         if(player!=null)
             Util.Message(player, MessageManager.msg.Success);
     }

--- a/src/main/java/cn/goldenpotato/tide/Config/Config.java
+++ b/src/main/java/cn/goldenpotato/tide/Config/Config.java
@@ -8,4 +8,5 @@ public class Config
     public List<String> worlds;
     public int maxTimeConsume;
     public boolean debug;
+    public boolean removeWaterLog;
 }

--- a/src/main/java/cn/goldenpotato/tide/Config/ConfigManager.java
+++ b/src/main/java/cn/goldenpotato/tide/Config/ConfigManager.java
@@ -45,6 +45,9 @@ public class ConfigManager
         reader.set("CalcRange", null); //删除旧版本的配置
         reader.set("FlowRange", null); //删除旧版本的配置
 
+        //WaterLog
+        config.removeWaterLog = reader.getBoolean("RemoveWaterLog", false);
+
         //Tide
         List<TideTime> tideTime = TideSystem.tideTime;
         ConfigurationSection in = reader.getConfigurationSection("Tide");
@@ -74,6 +77,7 @@ public class ConfigManager
         FileConfiguration writer = Tide.instance.getConfig();
         writer.set("Worlds", config.worlds);
         writer.set("MaxTimeConsume", config.maxTimeConsume);
+        writer.set("RemoveWaterLog", config.removeWaterLog);
         writer.set("Debug", config.debug);
         Tide.instance.saveConfig();
     }

--- a/src/main/java/cn/goldenpotato/tide/Config/Message.java
+++ b/src/main/java/cn/goldenpotato/tide/Config/Message.java
@@ -4,6 +4,7 @@ public class Message
 {
     public String NoCommandInConsole;
     public String NoPermission;
+    public String NoSuchWorld;
     public String WrongNum;
     public String Success;
     public String SubCommand_Add_Usage;

--- a/src/main/java/cn/goldenpotato/tide/Config/MessageManager.java
+++ b/src/main/java/cn/goldenpotato/tide/Config/MessageManager.java
@@ -85,6 +85,7 @@ public class MessageManager
     {
         msg.NoPermission = GetString("NoPermission");
         msg.NoCommandInConsole =  GetString("NoCommandInConsole");
+        msg.NoSuchWorld = GetString("NoSuchWorld");
         msg.WrongNum = GetString("WrongNum");
         msg.Success = GetString("Success");
         msg.SubCommand_Add_Usage = GetString("SubCommand_Add_Usage");

--- a/src/main/java/cn/goldenpotato/tide/Papi/PapiManager.java
+++ b/src/main/java/cn/goldenpotato/tide/Papi/PapiManager.java
@@ -1,0 +1,60 @@
+package cn.goldenpotato.tide.Papi;
+
+import cn.goldenpotato.tide.Util.Util;
+import cn.goldenpotato.tide.Water.TideSystem;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
+
+public class PapiManager extends PlaceholderExpansion
+{
+    @Override
+    public @NotNull String getIdentifier()
+    {
+        return "tide";
+    }
+
+    @Override
+    public @NotNull String getAuthor()
+    {
+        return "GoldenPotato137";
+    }
+
+    @Override
+    public @NotNull String getVersion()
+    {
+        return "2.1";
+    }
+
+    @Override
+    public boolean persist()
+    {
+        return true;
+    }
+
+    @Override
+    public String onRequest(OfflinePlayer player, @NotNull String params)
+    {
+        if(player==null || player.getPlayer()==null) return null;
+
+        World world = player.getPlayer().getWorld();
+        long tickNow = world.getTime();
+        switch (params)
+        {
+            case "level": //当前潮汐海平面偏移量
+                return String.valueOf(TideSystem.SeaLevel(world));
+            case "nextLevel": //下一次潮汐海平面偏移量
+                return String.valueOf(TideSystem.NextTide(tickNow).level);
+            case "nextTime": //下一次潮汐时间
+                return Util.TickToTime(TideSystem.NextTide(tickNow).tick);
+            case "nextTick": //下一次潮汐tick
+                return String.valueOf(TideSystem.NextTide(tickNow).tick);
+            case "nextTickCountDown": //距离下一次潮汐还有多少tick
+                return String.valueOf(TideSystem.NextTideCD(tickNow));
+            case "time": //当前时间
+                return Util.TickToTime(tickNow);
+        }
+        return null;
+    }
+}

--- a/src/main/java/cn/goldenpotato/tide/Tide.java
+++ b/src/main/java/cn/goldenpotato/tide/Tide.java
@@ -6,6 +6,7 @@ import cn.goldenpotato.tide.Config.MessageManager;
 import cn.goldenpotato.tide.Listener.ChunkListener;
 import cn.goldenpotato.tide.Listener.WaterListener;
 import cn.goldenpotato.tide.Metrics.Metrics;
+import cn.goldenpotato.tide.Papi.PapiManager;
 import cn.goldenpotato.tide.Water.TideSystem;
 import cn.goldenpotato.tide.Water.WaterCalculator;
 import org.bukkit.Bukkit;
@@ -36,6 +37,16 @@ public final class Tide extends JavaPlugin
 
         WaterCalculator.Init();
         TideSystem.Init();
+
+        //Register Papi
+        if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI")!=null)
+        {
+            new PapiManager().register();
+            if (ConfigManager.config.debug)
+                getLogger().info("PlaceholderAPI found, registered.");
+        }
+        else if (ConfigManager.config.debug)
+            getLogger().info("PlaceholderAPI not found.");
 
         //Metrics
         int pluginId = 15943;

--- a/src/main/java/cn/goldenpotato/tide/Util/Util.java
+++ b/src/main/java/cn/goldenpotato/tide/Util/Util.java
@@ -60,7 +60,7 @@ public class Util
 
     public static String TickToTime(long tick)
     {
-        long hour = (tick / 1000 + 7) % 24;
+        long hour = (tick / 1000 + 6) % 24;
         long minute = (int)((float)(tick % 1000) / (1000.0/60));
         return String.format("%02d:%02d", hour, minute);
     }

--- a/src/main/java/cn/goldenpotato/tide/Water/TideSystem.java
+++ b/src/main/java/cn/goldenpotato/tide/Water/TideSystem.java
@@ -156,7 +156,7 @@ public class TideSystem
                 }
     }
 
-    /** 获取当前海平面高度*/
+    /** 获取当前海平面高度偏移量*/
     public static int SeaLevel(World world)
     {
         return _seaLevel.get(world);

--- a/src/main/java/cn/goldenpotato/tide/Water/TideSystem.java
+++ b/src/main/java/cn/goldenpotato/tide/Water/TideSystem.java
@@ -163,6 +163,34 @@ public class TideSystem
     }
 
     /**
+     * 获取下一次潮汐变化的TideTime
+     * @param tickNow 当前时间
+     */
+    public static TideTime NextTide(long tickNow)
+    {
+        TideTime time = null;
+        for (TideTime t : TideSystem.tideTime)
+            if (tickNow < t.tick)
+            {
+                time = t;
+                break;
+            }
+        if (time == null)
+            time = TideSystem.tideTime.get(0);
+        return time;
+    }
+
+    /**
+     * 获取下一次潮汐变化的tick
+     * @param tickNow 当前时间
+     */
+    public static long NextTideCD(long tickNow)
+    {
+        TideTime ans = NextTide(tickNow);
+        return ans.tick >= tickNow ? ans.tick - tickNow : 24000 - tickNow + ans.tick;
+    }
+
+    /**
      * 计算引用计数（运行时加载世界时调用）
      * @param world 世界
      */

--- a/src/main/java/cn/goldenpotato/tide/Water/TideSystem.java
+++ b/src/main/java/cn/goldenpotato/tide/Water/TideSystem.java
@@ -11,6 +11,7 @@ import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -52,8 +53,9 @@ public class TideSystem
 
     /**
      * 加载世界及其chunk数据
+     * @param world 世界
      */
-    public static void Load(World world)
+    public static void Load(@NotNull World world)
     {
         if(worlds.contains(world)) return; //已经加载过了
 
@@ -158,5 +160,23 @@ public class TideSystem
     public static int SeaLevel(World world)
     {
         return _seaLevel.get(world);
+    }
+
+    /**
+     * 计算引用计数（运行时加载世界时调用）
+     * @param world 世界
+     */
+    public static void CalcNearbyChunk(@NotNull World world)
+    {
+        for(Chunk chunk : world.getLoadedChunks())
+        {
+            int[] dx={-1,1,0,0},dz={0,0,-1,1};
+            for(int i=0;i<4;i++)
+            {
+                ChunkLocation nearbyChunkLoc = new ChunkLocation(world,chunk.getX()+dx[i],chunk.getZ()+dz[i]);
+                ChunkData nearbyChunk = TideSystem.GetChunkData(nearbyChunkLoc);
+                nearbyChunk.loadedCount++;
+            }
+        }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,11 @@ Worlds: []
 #The longest calculation time allowed per tick, in milliseconds
 MaxTimeConsume: 10
 
+#是否在退潮的时候移除必须含水的方块（如水生植物）
+#Whether to remove blocks that must contain water (such as aquatic plants) during ebb
+#https://minecraft.fandom.com/wiki/Waterlogging
+RemoveWaterLog: false
+
 #潮汐时刻
 #Tide time
 #每一个小时对应1000tick，早上六点为0tick，依次类推，比如说早上七点为1000tick

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,8 +16,8 @@ MaxTimeConsume: 10
 
 #潮汐时刻
 #Tide time
-#每一个小时对应1000tick，早上七点为0tick，依次类推，比如说早上八点为1000tick
-#Every hour corresponds to 1000 tick, 0 tick at 7:00 in the morning, and so on, for example, 1000 tick at 8:00 in the morning
+#每一个小时对应1000tick，早上六点为0tick，依次类推，比如说早上七点为1000tick
+#Every hour corresponds to 1000 tick, 0 tick at 6:00 in the morning, and so on, for example, 1000 tick at 7:00 in the morning
 #Level表示距离初始海平面的潮汐高度差，正数表示高于初始海平面，负数表示低于初始海平面
 #Level represents the tidal height difference from the initial sea level,
 #a positive number means higher than the initial sea level, and a negative number means lower than the initial sea level

--- a/src/main/resources/message.yml
+++ b/src/main/resources/message.yml
@@ -3,6 +3,7 @@
 
 NoPermission: "§cYou don't have permission to use this command."
 NoCommandInConsole: "§cYou can't use command in the console."
+NoSuchWorld: "§cWorld not found: %world%"
 WrongNum: "§cWrong number."
 Success: "§aSuccess."
 SubCommand_Add_Usage: "§aUsage: /tide add：Set current location as water source"

--- a/src/main/resources/message_en-US.yml
+++ b/src/main/resources/message_en-US.yml
@@ -1,5 +1,6 @@
 NoPermission: "§cYou don't have permission to use this command."
 NoCommandInConsole: "§cYou can't use command in the console."
+NoSuchWorld: "§cWorld not found: %world%"
 WrongNum: "§cWrong number."
 Success: "§aSuccess."
 SubCommand_Add_Usage: "§aUsage: /tide add：Set current location as water source"

--- a/src/main/resources/message_zh-CN.yml
+++ b/src/main/resources/message_zh-CN.yml
@@ -1,5 +1,6 @@
 NoPermission: "§c你没有使用该指令的权限"
 NoCommandInConsole: "§c控制台不能使用指令"
+NoSuchWorld: "§c找不到该世界: %world%"
 WrongNum: "§c参数错误"
 Success: "§a成功！"
 SubCommand_Add_Usage: "§a用法: /tide add：将所在位置设置为水源"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,8 @@ authors: [ goldenpotato137@gmail.com ]
 load: STARTUP
 loadbefore:
   - Multiverse-Core
+softdepend:
+  - PlaceholderAPI
 commands:
   tide:
     description: "Tide"


### PR DESCRIPTION
* [feat: 修改本地化系统](https://github.com/GoldenPotato137/Tide/commit/8ef1f760d1ca0bb5bd2aaf60299b30e6a4db8329)
  * 新的运行时自动生成的本地化文件名为 'locale.yml'
  * 该文件将会以以下优先级生成本地化文件：已经存在的locale.yml(即有可能管理员修改过的)->翻译过后的message_xx-XX.yml -> 本地化文件原本message.yml(Chinglish)
* [feat: 新增reload与attach命令](https://github.com/GoldenPotato137/Tide/commit/4676b23524990e230e4e13319e874b4394442ad2) 
  * /tide reload: 重新加载配置
  * /tide attach [world]: 将指定世界/当前世界设置为潮汐世界
* [feat: 退潮时可以移除海带/水草了](https://github.com/GoldenPotato137/Tide/commit/2456a5840267cbc45116c1aea743760183fa7b40)
  *  新的选项在config中，老版本重启插件后可在config中找到
 * [feat: 新增了papi支持以及6个papi变量](https://github.com/GoldenPotato137/Tide/commit/dd2e7fe1ad8b1cc144d664f17205ca957d07a85e) 
   * level: 当前海平面偏移量
   * nextLevel： 下一次潮汐海平面偏移量
   * nextTime： 下一次潮汐时间
   * nextTick： 下一次潮汐的tick
   * nextTickCountDown： 距离下一次潮汐还有多少tick
   * time： 当前时间
* [fix: 修复插件0tick时间到早上六点](https://github.com/GoldenPotato137/Tide/commit/2f885c1c806b1656871d6cdd18e5efd1a2f39a66) 
  * 与Minecraft默认的时间设计同步 